### PR TITLE
Handled crash when subscribing to invalid topic

### DIFF
--- a/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
+++ b/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
@@ -39,6 +39,7 @@ import org.eclipse.paho.client.mqttv3.MqttAsyncClient
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttException
+import org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_INVALID_SUBSCRIPTION
 import org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_UNEXPECTED_ERROR
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.MqttSecurityException
@@ -487,12 +488,11 @@ internal class MqttConnection(
             } catch (illegalArgumentException: IllegalArgumentException) {
                 connectionConfig.connectionEventHandler.onMqttSubscribeFailure(
                     topics = topicMap,
-                    throwable = illegalArgumentException,
+                    throwable = MqttException(
+                        REASON_CODE_INVALID_SUBSCRIPTION.toInt(),
+                        illegalArgumentException
+                    ),
                     timeTakenMillis = (clock.nanoTime() - subscribeStartTime).fromNanosToMillis()
-                )
-                runnableScheduler.scheduleMqttHandleExceptionRunnable(
-                    illegalArgumentException,
-                    false
                 )
             }
         }

--- a/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
+++ b/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
@@ -484,6 +484,16 @@ internal class MqttConnection(
                     timeTakenMillis = (clock.nanoTime() - subscribeStartTime).fromNanosToMillis()
                 )
                 runnableScheduler.scheduleMqttHandleExceptionRunnable(mqttException, true)
+            } catch (illegalArgumentException: IllegalArgumentException) {
+                connectionConfig.connectionEventHandler.onMqttSubscribeFailure(
+                    topics = topicMap,
+                    throwable = illegalArgumentException,
+                    timeTakenMillis = (clock.nanoTime() - subscribeStartTime).fromNanosToMillis()
+                )
+                runnableScheduler.scheduleMqttHandleExceptionRunnable(
+                    illegalArgumentException,
+                    false
+                )
             }
         }
     }

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttException.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttException.java
@@ -144,6 +144,12 @@ public class MqttException extends Exception
 	 */
 	public static final short REASON_CODE_DISCONNECTED_BUFFER_FULL	= 32203;
 
+	/**
+	 * The Client has attempted to subscribe to an invalid topic.
+	 */
+
+	public static final short REASON_CODE_INVALID_SUBSCRIPTION = 32204;
+
 	private int reasonCode;
 
 	private Throwable cause;


### PR DESCRIPTION
**Fix for https://github.com/gojek/courier-android/issues/32#issue-1306745655**

There is a crash when we try to connect to an invalid topic. 
For example **home#** or **home+**

Steps to reproduce -:

1. Connect to a MQTT broker
2. Subscribe to an invalid topic name. Example `home#`

Error Logs -:

```
2022-07-16 13:45:37.778 10608-10647/com.gojek.courier.app E/AndroidRuntime: FATAL EXCEPTION: MQTT_Thread
    Process: com.gojek.courier.app, PID: 10608
    java.lang.IllegalArgumentException: Invalid usage of multi-level wildcard in topic string: home#
        at org.eclipse.paho.client.mqttv3.MqttTopic.validate(MqttTopic.java:200)
        at org.eclipse.paho.client.mqttv3.MqttAsyncClient.subscribe(MqttAsyncClient.java:889)
        at com.gojek.mqtt.connection.MqttConnection.subscribe(MqttConnection.kt:474)
        at com.gojek.mqtt.client.v3.impl.AndroidMqttClient.subscribeMqtt(AndroidMqttClient.kt:465)
        at com.gojek.mqtt.scheduler.runnable.SubscribeRunnable.run(SubscribeRunnable.kt:11)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```

[Video for your reference](https://drive.google.com/file/d/1_CPONzLarm94XSaaRp78O-GmxpL95eMX/view?usp=sharing)