### PR TITLE
Add new implementation of RunnableScheduler which stops the thread on destroy

### DIFF
--- a/courier/src/main/java/com/gojek/courier/Courier.kt
+++ b/courier/src/main/java/com/gojek/courier/Courier.kt
@@ -11,7 +11,7 @@ import com.gojek.courier.utils.RuntimePlatform
 import com.gojek.courier.utils.StreamAdapterResolver
 import com.gojek.mqtt.client.MqttClient
 
-class Courier(configuration: Configuration) {
+class Courier(private val configuration: Configuration) {
     private val stubInterfaceFactory: StubInterface.Factory
     private val proxyFactory: ProxyFactory
     private val coordinator: Coordinator
@@ -42,6 +42,9 @@ class Courier(configuration: Configuration) {
      */
     inline fun <reified T : Any> create(): T = create(T::class.java)
 
+    fun newBuilder(): Builder {
+        return Builder(configuration)
+    }
     data class Configuration(
         val client: MqttClient,
         val streamAdapterFactories: List<StreamAdapter.Factory> = emptyList(),
@@ -55,5 +58,26 @@ class Courier(configuration: Configuration) {
 
     private fun Configuration.createMessageAdapterResolver(): MessageAdapterResolver {
         return MessageAdapterResolver(messageAdapterFactories)
+    }
+
+    class Builder(private var configuration: Configuration) {
+
+        fun addMessageAdapterFactories(messageAdapterFactories: List<MessageAdapter.Factory>): Builder {
+            configuration = configuration.copy(
+                messageAdapterFactories = messageAdapterFactories + configuration.messageAdapterFactories
+            )
+            return this
+        }
+
+        fun addStreamAdapterFactories(streamAdapterFactories: List<StreamAdapter.Factory>): Builder {
+            configuration = configuration.copy(
+                streamAdapterFactories = streamAdapterFactories + configuration.streamAdapterFactories
+            )
+            return this
+        }
+
+        fun build(): Courier {
+            return Courier(configuration)
+        }
     }
 }


### PR DESCRIPTION
#31 Create a new implementation of `IRunnableScheduler` which stops the thread when destroy api of `MqttClient` is invoked. The thread is started again when connect api is invoked. 

To use this new implementation, pass the config `isRunnableSchedulerV2Enabled` as true inside `ExperimentConfigs`