### PR TITLE
Add handling for subscription not ack by broker

### DIFF
--- a/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
+++ b/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
@@ -530,7 +530,7 @@ internal class MqttConnection(
                 val successTopicMap = mutableMapOf<String, QoS>()
                 val failTopicMap = mutableMapOf<String, QoS>()
                 iMqttToken.topics.forEachIndexed { index, topic ->
-                    if (128 == iMqttToken.grantedQos.getOrNull(index)) {
+                    if (128 == (iMqttToken.response as? MqttSuback)?.grantedQos?.getOrNull(index)) {
                         failTopicMap[topic] = topicMap[topic] ?: ONE
                     } else {
                         successTopicMap[topic] = topicMap[topic] ?: ONE

--- a/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
+++ b/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
@@ -3,7 +3,6 @@ package com.gojek.mqtt.connection
 import android.content.Context
 import android.os.SystemClock
 import com.gojek.courier.QoS
-import com.gojek.courier.QoS.ONE
 import com.gojek.courier.extensions.fromNanosToMillis
 import com.gojek.courier.logging.ILogger
 import com.gojek.courier.utils.Clock
@@ -531,9 +530,9 @@ internal class MqttConnection(
                 val failTopicMap = mutableMapOf<String, QoS>()
                 iMqttToken.topics.forEachIndexed { index, topic ->
                     if (128 == (iMqttToken.response as? MqttSuback)?.grantedQos?.getOrNull(index)) {
-                        failTopicMap[topic] = topicMap[topic] ?: ONE
+                        failTopicMap[topic] = topicMap[topic]!!
                     } else {
-                        successTopicMap[topic] = topicMap[topic] ?: ONE
+                        successTopicMap[topic] = topicMap[topic]!!
                     }
                 }
 
@@ -548,7 +547,7 @@ internal class MqttConnection(
                     connectionConfig.connectionEventHandler.onMqttSubscribeFailure(
                         topics = failTopicMap,
                         timeTakenMillis = (clock.nanoTime() - context.startTime).fromNanosToMillis(),
-                        throwable = MqttException(MqttException.REASON_CODE_SUBSCRIPTION_NOT_ACK.toInt())
+                        throwable = MqttException(MqttException.REASON_CODE_INVALID_SUBSCRIPTION.toInt())
                     )
                 }
 

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/IMqttToken.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/IMqttToken.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.paho.client.mqttv3;
 
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
+
 /**
  * Provides a mechanism for tracking the completion of an asynchronous task.
  * 
@@ -136,5 +138,15 @@ public interface IMqttToken
 	 * operations as there can only ever be one of these outstanding at a time. For other operations the MQTT message id flowed over the network.
 	 */
 	public int getMessageId();
+
+	/**
+	 * @return the granted QoS list from a suback
+	 */
+	int[] getGrantedQos();
+
+	/**
+	 * @return the response wire message
+	 */
+	MqttWireMessage getResponse();
 
 }

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/IMqttToken.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/IMqttToken.java
@@ -140,11 +140,6 @@ public interface IMqttToken
 	public int getMessageId();
 
 	/**
-	 * @return the granted QoS list from a suback
-	 */
-	int[] getGrantedQos();
-
-	/**
 	 * @return the response wire message
 	 */
 	MqttWireMessage getResponse();

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttException.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttException.java
@@ -147,7 +147,6 @@ public class MqttException extends Exception
 	/**
 	 * The Client has attempted to subscribe to an invalid topic.
 	 */
-
 	public static final short REASON_CODE_INVALID_SUBSCRIPTION = 32204;
 
 	private int reasonCode;

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttToken.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttToken.java
@@ -97,10 +97,6 @@ public class MqttToken implements IMqttToken, IToken
 		return internalTok.getMessageID();
 	}
 
-	public int[] getGrantedQos() {
-		return internalTok.getGrantedQos();
-	}
-
 	public MqttWireMessage getResponse() {
 		return internalTok.getResponse();
 	}

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttToken.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/MqttToken.java
@@ -14,6 +14,7 @@
 package org.eclipse.paho.client.mqttv3;
 
 import org.eclipse.paho.client.mqttv3.internal.Token;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
 
 /**
  * Provides a mechanism for tracking the completion of an asynchronous action.
@@ -94,5 +95,13 @@ public class MqttToken implements IMqttToken, IToken
 	public int getMessageId()
 	{
 		return internalTok.getMessageID();
+	}
+
+	public int[] getGrantedQos() {
+		return internalTok.getGrantedQos();
+	}
+
+	public MqttWireMessage getResponse() {
+		return internalTok.getResponse();
 	}
 }

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsCallback.java
@@ -25,12 +25,8 @@ import org.eclipse.paho.client.mqttv3.MqttToken;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttPubAck;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttPubComp;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttPublish;
-import org.eclipse.paho.client.mqttv3.internal.wire.MqttSuback;
 
-import java.util.Arrays;
 import java.util.Vector;
-
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_SUBSCRIPTION_NOT_ACK;
 
 /**
  * Bridge between Receiver and the external API. This class gets called by Receiver, and then converts the comms-centric MQTT message objects into ones understood by the external
@@ -336,28 +332,7 @@ public class CommsCallback implements Runnable, ICommsCallback
 			IMqttActionListener asyncCB = token.getActionCallback();
 			if (asyncCB != null)
 			{
-
-				if (token.getResponse() instanceof MqttSuback)
-				{
-					boolean isAnySubscriptionFailed = false;
-					int [] grantedQos = token.getGrantedQos();
-					for (int qos : grantedQos) {
-						if (qos == 128) {
-							isAnySubscriptionFailed = true;
-							break;
-						}
-					}
-					if (isAnySubscriptionFailed)
-					{
-						asyncCB.onFailure(token, new MqttException(REASON_CODE_SUBSCRIPTION_NOT_ACK));
-					}
-					else
-					{
-						asyncCB.onSuccess(token);
-					}
-				}
-
-				else if (token.getException() == null)
+				if (token.getException() == null)
 				{
 					// @TRACE 716=call onSuccess key={0}
 

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
@@ -437,14 +437,4 @@ public class Token
 		return response;
 	}
 
-	public int[] getGrantedQos() {
-		int[] val = new int[0];
-		if (response instanceof MqttSuback) {
-			if (response != null) {
-				val = ((MqttSuback) response).getGrantedQos();
-			}
-		}
-		return val;
-	}
-
 }

--- a/paho/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
+++ b/paho/src/main/java/org/eclipse/paho/client/mqttv3/internal/Token.java
@@ -18,6 +18,7 @@ import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttAck;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttSuback;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
 
 public class Token
@@ -430,6 +431,20 @@ public class Token
 		tok.append(" ,actioncallback=" + getActionCallback());
 
 		return tok.toString();
+	}
+
+	public MqttWireMessage getResponse() {
+		return response;
+	}
+
+	public int[] getGrantedQos() {
+		int[] val = new int[0];
+		if (response instanceof MqttSuback) {
+			if (response != null) {
+				val = ((MqttSuback) response).getGrantedQos();
+			}
+		}
+		return val;
 	}
 
 }


### PR DESCRIPTION
When the client is trying to subscribe to topics if the broker is not able to subscribe successfully we get a SUBACK from broker with grantedQos of 128. In this case, currently we still get `MqttSubscribeSuccessEvent` form the library leading to false positives.  

The change is to provide a failure in this case which leads to retrying the subscription request internally and once the MAX retry is exhausted provide a `MqttSubscribeFailureEvent` to the client and keep retrying internally.

This handles the scenario where the broker has not successfully subscribed and the same is communicated to the client via the library.

https://github.com/gojek/courier-android/issues/37