### PR TITLE
Handled crash while unsubscribing to invalid topic length

### DIFF
--- a/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
+++ b/mqtt-client/src/main/java/com/gojek/mqtt/connection/MqttConnection.kt
@@ -537,6 +537,15 @@ internal class MqttConnection(
                     timeTakenMillis = (clock.nanoTime() - unsubscribeStartTime).fromNanosToMillis()
                 )
                 runnableScheduler.scheduleMqttHandleExceptionRunnable(mqttException, true)
+            } catch (illegalArgumentException: IllegalArgumentException) {
+                connectionConfig.connectionEventHandler.onMqttUnsubscribeFailure(
+                    topics = topics,
+                    throwable = MqttException(
+                        REASON_CODE_INVALID_SUBSCRIPTION.toInt(),
+                        illegalArgumentException
+                    ),
+                    timeTakenMillis = (clock.nanoTime() - unsubscribeStartTime).fromNanosToMillis()
+                )
             }
         }
     }


### PR DESCRIPTION
There is a crash when we try to unsubscribe to an invalid topic.
For example empty string ""

Steps to reproduce -:
- Connect to an MQTT broker
- Subscribe to an invalid topic name. Example home#

Error Logs -:
```
2023-06-05 15:32:52.720 10802-10897/com.gojek.courier.app E/AndroidRuntime: FATAL EXCEPTION: MQTT_Thread
    Process: com.gojek.courier.app, PID: 10802
    java.lang.IllegalArgumentException: Invalid topic length, should be in range[1, 65535]!
        at org.eclipse.paho.client.mqttv3.MqttTopic.validate(MqttTopic.java:175)
        at org.eclipse.paho.client.mqttv3.MqttAsyncClient.unsubscribe(MqttAsyncClient.java:1023)
        at com.gojek.mqtt.connection.MqttConnection.unsubscribe(MqttConnection.kt:528)
        at com.gojek.mqtt.client.v3.impl.AndroidMqttClient.unsubscribeMqtt(AndroidMqttClient.kt:478)
        at com.gojek.mqtt.scheduler.runnable.UnsubscribeRunnable.run(UnsubscribeRunnable.kt:10)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at android.os.Looper.loop(Looper.java:224)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```