### PR TITLE
Update Node for github pages Job

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Build website
         run: |


### PR DESCRIPTION
https://github.com/gojek/courier-android/actions/runs/11685331939

Github Publish Page job is failing for merged commit, this pull request is to ressolve issue by upgrading the node version to 18.x