### PR TITLE
Add missing topic parameter in message adapter tests

### DIFF
--- a/courier-message-adapter-moshi/src/test/java/com/gojek/courier/messageadapter/moshi/MoshiMessageAdapterTest.kt
+++ b/courier-message-adapter-moshi/src/test/java/com/gojek/courier/messageadapter/moshi/MoshiMessageAdapterTest.kt
@@ -27,7 +27,7 @@ class MoshiMessageAdapterTest {
         val testClass = TestClass(100, "test100")
         val testString = """{"id":100,"name":"test100"}"""
 
-        val message = moshiMessageAdapter.toMessage(testClass)
+        val message = moshiMessageAdapter.toMessage(topic = "any", data = testClass)
 
         assertEquals(testString, String((message as Message.Bytes).value))
     }
@@ -38,7 +38,8 @@ class MoshiMessageAdapterTest {
         val testString = """{"id":100,"name":"test100"}"""
 
         val message = moshiMessageAdapter.fromMessage(
-            Message.Bytes(testString.toByteArray())
+            topic = "any",
+            message = Message.Bytes(testString.toByteArray())
         )
 
         assertEquals(testClass, message)

--- a/courier-message-adapter-protobuf/src/test/java/com/gojek/courier/messageadapter/protobuf/ProtobufMessageAdapterTest.kt
+++ b/courier-message-adapter-protobuf/src/test/java/com/gojek/courier/messageadapter/protobuf/ProtobufMessageAdapterTest.kt
@@ -19,7 +19,7 @@ class ProtobufMessageAdapterTest {
     fun serialise() {
         val user = User.newBuilder().setId(123).setName("Test").build()
         val encodedString = "CgRUZXN0EHs="
-        val userMessage = protobufMessageAdapter.toMessage(user)
+        val userMessage = protobufMessageAdapter.toMessage(topic = "any", data = user)
         val userString = String(Base64.getEncoder().encode((userMessage as Message.Bytes).value))
         assertEquals(userString, encodedString)
     }
@@ -28,7 +28,10 @@ class ProtobufMessageAdapterTest {
     fun deserialise() {
         val encodedString = "CgRUZXN0EHs="
         val byteArray = Base64.getDecoder().decode(encodedString)
-        val user = protobufMessageAdapter.fromMessage(Message.Bytes(byteArray))
+        val user = protobufMessageAdapter.fromMessage(
+            topic = "any",
+            message = Message.Bytes(byteArray)
+        )
         assertEquals(user.id, 123)
         assertEquals(user.name, "Test")
     }
@@ -36,6 +39,9 @@ class ProtobufMessageAdapterTest {
     @Test(expected = RuntimeException::class)
     fun deserialiseEmpty() {
         val byteArray = ByteArray(0)
-        protobufMessageAdapter.fromMessage(Message.Bytes(byteArray))
+        protobufMessageAdapter.fromMessage(
+            topic = "any",
+            message = Message.Bytes(byteArray)
+        )
     }
 }

--- a/courier-message-adapter-text/src/test/java/com/gojek/courier/messageadapter/text/ExampleUnitTest.kt
+++ b/courier-message-adapter-text/src/test/java/com/gojek/courier/messageadapter/text/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.gojek.courier.messageadapter.gson
+package com.gojek.courier.messageadapter.text
 
 import org.junit.Assert.assertEquals
 import org.junit.Test


### PR DESCRIPTION
After adding `topic` parameter to `MessageAdapter` interface (PR #48), compilation of the tests failed.